### PR TITLE
add overflow:hidden to html to disable scroll

### DIFF
--- a/js/src/menu.js
+++ b/js/src/menu.js
@@ -47,6 +47,7 @@
    * Initialise Menu.
    */
   Menu.prototype._init = function() {
+    this.html = document.getElementsByTagName( 'html' )[0];
     this.body = document.body;
     this.wrapper = document.querySelector(this.options.wrapper);
     this.mask = document.querySelector(this.options.maskId);
@@ -77,6 +78,7 @@
    * Open Menu.
    */
   Menu.prototype.open = function() {
+    this.html.classList.add('has-active-menu');
     this.body.classList.add('has-active-menu');
     this.wrapper.classList.add('has-' + this.options.type);
     this.menu.classList.add('is-active');
@@ -88,6 +90,7 @@
    * Close Menu.
    */
   Menu.prototype.close = function() {
+    this.html.classList.remove('has-active-menu');
     this.body.classList.remove('has-active-menu');
     this.wrapper.classList.remove('has-' + this.options.type);
     this.menu.classList.remove('is-active');


### PR DESCRIPTION
On Chrome and Safari I noticed they don't respect body overflow: hidden unless you also apply it to the HTML element. This updates the code to do that, so that users can't carry on swiping down when a menu is open and they reach the bottom.
